### PR TITLE
Update async version to 0.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     }
   ],
   "dependencies": {
-    "async": "0.2.x",
+    "async": "0.9.x",
     "bl": "^0.9.0",
     "readable-stream": "1.0.15"
   },


### PR DESCRIPTION
- Fixes issue with using Intern and Supertest AMD loader
